### PR TITLE
Add feature for bytecode execution for arrays(few), Declaration

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -181,7 +181,7 @@ class Parser:
         if not isinstance(l, Identifier):
             ParseError(self, f"Expected an identifier", l.lineNumber)
         self.lexer.advance()
-        var = Variable(l.lineNumber, l.val, generate_id())
+        var = Variable(l.lineNumber, l.val, generate_id(), 0)
         self.lexer.match(Operator(0,")"))
         self.lexer.match(Operator(0,";"))
         return array_remove(lineNumber, index, var)
@@ -203,7 +203,7 @@ class Parser:
         self.lexer.advance()
         self.lexer.match(Operator(0,")"))
         self.lexer.match(Operator(0,";"))
-        var = Variable(l.lineNumber, l.val, generate_id())
+        var = Variable(l.lineNumber, l.val, generate_id(), 0)
         return array_pop(l.lineNumber, var)
     
     def parse_insert(self):
@@ -298,7 +298,7 @@ class Parser:
             case Identifier(lineNumber, name):
                 i = self.lexer.peek_token()
                 self.lexer.advance()
-                return Variable(lineNumber, name, generate_id())
+                return Variable(lineNumber, name, generate_id(), 0)
                 
             case Keyword(lineNumber, "slice"):
                 self.lexer.advance()
@@ -539,7 +539,7 @@ class Parser:
         
         # Generating a Variable for the function
         f = self.lexer.peek_token()
-        func = Variable(f.lineNumber, f.val, generate_id())
+        func = Variable(f.lineNumber, f.val, generate_id(), 0)
         self.lexer.advance()
 
         # Checking for the "("
@@ -569,7 +569,7 @@ class Parser:
             # Obtaining the parameter name and appending to the params array
             iden = self.lexer.peek_token()
             self.lexer.advance()
-            params.append(Variable(iden.lineNumber, iden.val, generate_id()))
+            params.append(Variable(iden.lineNumber, iden.val, generate_id(), 0))
 
             # Checking for the "," if there are more parameters
             if self.lexer.peek_token().val == ',':
@@ -769,7 +769,7 @@ class Parser:
         iden = self.lexer.peek_token()
         if (not isinstance(iden, Identifier)):
             ParseError(self, "Expected Identifier.", iden.lineNumber)
-        var = Variable(iden.lineNumber, iden.val, generate_id())
+        var = Variable(iden.lineNumber, iden.val, generate_id(), 0)
         self.lexer.advance()
         if self.lexer.peek_token().val == "=":
             self.lexer.advance()
@@ -787,7 +787,7 @@ class Parser:
             ParseError(self, "Expected Identifier.", iden.lineNumber)
         # Adding the class name to the classList
         classList.append(iden.val)
-        var = Variable(iden.lineNumber, iden.val, generate_id())
+        var = Variable(iden.lineNumber, iden.val, generate_id(), 0)
         self.lexer.advance()
         self.lexer.match(Operator(0, "{"))
         stmts={}

--- a/sim.py
+++ b/sim.py
@@ -42,6 +42,7 @@ class Variable():
     lineNumber: int
     name: str
     id: int
+    localID: int
 
     def __repr__(self):
         return f"{self.name}::{self.id}"
@@ -507,7 +508,7 @@ def evaluate(program: AST, scopes: Scopes = None):
             return obj
         
         case This(lineNumber, id):
-            return scopes.getVariable(Variable(lineNumber, "this", id ))
+            return scopes.getVariable(Variable(lineNumber, "this", id, 0))
         
         case zArray(dtype, value) as arr:
             for i in range(len(arr.elements)):
@@ -790,7 +791,7 @@ def evaluate(program: AST, scopes: Scopes = None):
                     scopes.beginScope()
 
                     # Declaring the this variable
-                    scopes.declareVariable(Variable(lineNumber, "this", obj.zClass.thisID), obj, instanceType(obj.zClass), False)
+                    scopes.declareVariable(Variable(lineNumber, "this", obj.zClass.thisID, 0), obj, instanceType(obj.zClass), False)
 
                     # Declaring the function
                     evaluate(field, scopes)

--- a/test.zebra
+++ b/test.zebra
@@ -1,6 +1,7 @@
-var array(int) a = array(int) {1,2,3};
-
-var array(int) b = a + array(int){};
-a[0] = 5;
-
-zout(b);
+var array(int) a = array(int){1,2,3};
+zout(a);
+append(1, a);
+zout(a);
+zout(a[0]);
+a[0] = 20;
+zout(a[0]);

--- a/tests/collatz.zebra
+++ b/tests/collatz.zebra
@@ -1,63 +1,53 @@
-var int l = 100;
+var int l = 1000000;
 var array(int) a=array(int){};
 var int mem = 1000000;
 
 for(var int i=0;i<mem;i=i+1){
-    
     append(0,a);
 }
 
-func int longestCollatz() {
-    var int maxChainLength = 0;
-    var int result = 0;
-    
-    
-    for (var int i = 1; i < l; i=i+1) {
-        var int n = i;
-        var int chainLength = 1;
-        
-        var int flag = 0;
+var int maxChainLength = 0;
+var int result = 0;
+var int n = nil;
+var int chainLength = nil;
+var int flag = 0;
 
-        while (n > 1) 
-        {
-            
-           
-            if (n<mem){
-                if (a[n]!=0){
-                    chainLength = chainLength + a[n] -1;
-                    flag = 1;
-                    
-                    n = 0;
-                }
-            }
-            
-            if (flag ==0){
+for (var int i = 1; i < l; i=i+1) {
+    n = i;
+    chainLength = 1;
+    flag = 0;
 
-                if (n % 2 == 0) {
-                    n = n//2;
-
-                } 
-                else {
-                    n = 3 * n + 1;
-                }
-                chainLength = chainLength + 1;
+    while (n > 1) 
+    {
+        if (n<mem){
+            if (a[n]!=0){
+                chainLength = chainLength + a[n] -1;
+                flag = 1;
+                
+                n = 0;
             }
         }
         
-        if (chainLength > maxChainLength) {
-            maxChainLength = chainLength;
-            result = i;
-        }
-        if (i<mem) {a[i]=chainLength;}
-        
-        
+        if (flag ==0){
 
-    
+            if (n % 2 == 0) {
+                n = n//2;
+
+            } 
+            else {
+                n = 3 * n + 1;
+            }
+            chainLength = chainLength + 1;
+        }
     }
-    return result;
     
+    if (chainLength > maxChainLength) {
+        maxChainLength = chainLength;
+        result = i;
+    }
+    if (i<mem) {a[i]=chainLength;}
 }
 
-var int answer = longestCollatz();
 
-zout(answer);
+zout("result", result);
+zout("len", maxChainLength);

--- a/typechecking.py
+++ b/typechecking.py
@@ -109,7 +109,7 @@ def typecheck(program: AST, scopes = None):
             return Str
         
         case This(lineNumber, id):
-            return scopes.getVariableType(Variable(lineNumber, "this", id))
+            return scopes.getVariableType(Variable(lineNumber, "this", id, 0))
 
         case nil():
             return nil
@@ -568,7 +568,7 @@ def typecheck(program: AST, scopes = None):
             scopes.beginScope()
             
             # Declaring a dummy this variable
-            scopes.declareVariable(Variable(lineNumber, "this", thisID), InstanceObject(classObj, {}), instanceType(classObj), False)
+            scopes.declareVariable(Variable(lineNumber, "this", thisID, 0), InstanceObject(classObj, {}), instanceType(classObj), False)
 
             for stmt in stmts:
                 stmt = stmts[stmt]
@@ -579,7 +579,7 @@ def typecheck(program: AST, scopes = None):
                         value = createDummyObject(value)
                     if ((not isinstance(stmt.dtype, type)) and isinstance(stmt.dtype, instanceType)):
                         stmt.dtype = instanceType(scopes.getVariable(stmt.dtype.name))
-                    scopes.getVariable(Variable(lineNumber, "this", thisID)).fields[stmt.var.name] = [value , stmt.dtype, stmt.isConst]
+                    scopes.getVariable(Variable(lineNumber, "this", thisID, 0)).fields[stmt.var.name] = [value , stmt.dtype, stmt.isConst]
                 elif isinstance(stmt, DeclareFun):
                     typecheck(stmt, scopes)
                 else:
@@ -612,7 +612,7 @@ def typecheck(program: AST, scopes = None):
                         scopes.beginScope()
 
                         # Declaring the this variable
-                        scopes.declareVariable(Variable(lineNumber, "this", classObj.thisID), nil(), instanceType(classObj), False)
+                        scopes.declareVariable(Variable(lineNumber, "this", classObj.thisID, 0), nil(), instanceType(classObj), False)
 
                         # Declaring the function
                         scopes.declareFun(field.var, FnObject(field.functionType, field.params_type, field.params, field.body, field.return_type))


### PR DESCRIPTION
Now one can execute files using modes(options -bc, -et):
**et:** give the evaluation time for the program
**bc:** Generate bytecode and execute the program using a VM(instead of tree walk)
**Examples:**
```
python3 zebra.py filename [-bt] [-et]
```